### PR TITLE
Block & fail early if produce requests don't work

### DIFF
--- a/kafka-plaintext/1_kafka_producer.ipynb
+++ b/kafka-plaintext/1_kafka_producer.ipynb
@@ -107,9 +107,8 @@
     "        time.sleep(delay)\n",
     "        jsonpayload = json.dumps({'txt': f'hello {x}'})\n",
     "        print(f'sending {jsonpayload}')\n",
-    "        producer.send(KAFKA_TOPIC, jsonpayload.encode('utf-8'))\n",
-    "\n",
-    "    producer.flush()  # Important, especially if message size is small\n"
+    "        future = producer.send(KAFKA_TOPIC, jsonpayload.encode('utf-8'))\n",
+    "        future.get(timeout=60)"
    ]
   },
   {

--- a/kafka-sasl-plain/1_kafka_producer.ipynb
+++ b/kafka-sasl-plain/1_kafka_producer.ipynb
@@ -117,9 +117,8 @@
     "        time.sleep(delay)\n",
     "        jsonpayload = json.dumps({'txt': f'hello {x}'})\n",
     "        print(f'sending {jsonpayload}')\n",
-    "        producer.send(KAFKA_TOPIC, jsonpayload.encode('utf-8'))\n",
-    "\n",
-    "    producer.flush()  # Important, especially if message size is small\n"
+    "        future = producer.send(KAFKA_TOPIC, jsonpayload.encode('utf-8'))\n",
+    "        future.get(timeout=60)"
    ]
   },
   {


### PR DESCRIPTION
The kafka-python docs[1] note that `producer.flush()` only blocks
until all messages are put on the network, and it doesn't guarantee
delivery or success. Even if the provided credentials correspond to a
principal that doesn't have permission to produce to the topic,
everything might look like it has succeeded to the user:

```
>>> produce_messages(1, 10, 2)
sending {"txt": "hello 1"}
sending {"txt": "hello 2"}
sending {"txt": "hello 3"}
sending {"txt": "hello 4"}
sending {"txt": "hello 5"}
sending {"txt": "hello 6"}
sending {"txt": "hello 7"}
sending {"txt": "hello 8"}
sending {"txt": "hello 9"}
sending {"txt": "hello 10"}
```

The change proposed here (also based on the docs[1]) will cause each
iteration of the loop to block until the produce request has either
succeeded or failed:

```
>>> produce_messages(1, 10, 2)
sending {"txt": "hello 1"}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 25, in produce_messages
  File "/var/home/gryan/.local/lib/python3.10/site-packages/kafka/producer/future.py", line 65, in get
    raise self.exception # pylint: disable-msg=raising-bad-type
kafka.errors.TopicAuthorizationFailedError: [Error 29] TopicAuthorizationFailedError: python-test
```

NOTE: I haven't actually tried this notebook out, as I don't know how
to run notebooks yet and haven't set up an environment for that -- I
was just trying to understand why a buddy was not seeing a failure
when they should have, when running the code from this notebook. I
just copied the code from here into my local python interpreter. I
don't know if there's any special way that exceptions should be
handled in notebooks or anything like that.

[1] https://pypi.org/project/kafka-python/